### PR TITLE
feat(ui): Add CoinRowView with previews for different holding column …

### DIFF
--- a/CryptoAppSwiftUI.xcodeproj/xcuserdata/omerfarukdikili.xcuserdatad/xcdebugger/Breakpoints_v2.xcbkptlist
+++ b/CryptoAppSwiftUI.xcodeproj/xcuserdata/omerfarukdikili.xcuserdatad/xcdebugger/Breakpoints_v2.xcbkptlist
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Bucket
+   uuid = "BEED1D7F-B078-4D9B-80B0-3240E335C73C"
+   type = "1"
+   version = "2.0">
+   <Breakpoints>
+      <BreakpointProxy
+         BreakpointExtensionID = "Xcode.Breakpoint.FileBreakpoint">
+         <BreakpointContent
+            uuid = "EB0ACEBE-A5AC-401A-B9DF-8EAEC2161A7A"
+            shouldBeEnabled = "No"
+            ignoreCount = "0"
+            continueAfterRunningActions = "No"
+            filePath = "CryptoAppSwiftUI/Core/HomeView/View/HomeView.swift"
+            startingColumnNumber = "9223372036854775807"
+            endingColumnNumber = "9223372036854775807"
+            startingLineNumber = "52"
+            endingLineNumber = "52"
+            landmarkName = "body"
+            landmarkType = "24">
+         </BreakpointContent>
+      </BreakpointProxy>
+   </Breakpoints>
+</Bucket>

--- a/CryptoAppSwiftUI/Core/HomeView/View/CoinRowView.swift
+++ b/CryptoAppSwiftUI/Core/HomeView/View/CoinRowView.swift
@@ -1,0 +1,73 @@
+//
+//  CoinRowView.swift
+//  CryptoAppSwiftUI
+//
+//  Created by Ömer Faruk Dikili on 8.02.2025.
+//
+
+import Foundation
+import SwiftUI
+
+struct CoinRowView: View {
+    let coin : CoinModel
+    let  showHoldingColumn : Bool
+    var body: some View {
+        HStack{
+            leftColumn
+            Spacer()
+            if showHoldingColumn{
+                centerColumn
+            }
+            rightColumn
+        }
+        .font(.subheadline)
+    }
+}
+
+extension CoinRowView{
+    private var leftColumn : some View{
+        HStack(spacing: 0){
+            Text("\(coin.rank)")
+                .font(.caption)
+                .foregroundStyle(Color.theme.secondaryTextColor)
+                .frame(minWidth: 30)
+            Circle()
+                .frame(width: 30, height: 30)
+            Text(coin.name)
+                .font(.headline)
+                .padding(.leading, 6)
+                .foregroundStyle(Color.theme.accent)
+        }
+    }
+    
+    private var centerColumn : some View{
+        VStack(alignment:.trailing){
+            Text("\(coin.currentHoldingsValue,specifier: "%.2f")")
+                .bold()
+            Text("\(coin.currentHoldings ?? 0,specifier: "%.2f")")
+        }
+        .foregroundStyle(Color.theme.accent)
+    }
+    
+    private var rightColumn : some View{
+        VStack(alignment:.trailing){
+            Text("$\(coin.currentPrice,specifier: "%.2f")")
+                .bold()
+                .foregroundStyle(Color.theme.accent)
+            Text("\(coin.priceChangePercentage24H ?? 0)")
+                .foregroundStyle((coin.priceChangePercentage24H ?? 0) >= 0 ? Color.theme.greenColor : Color.theme.redColor)
+        }.frame(width: UIScreen.main.bounds.width/3,alignment: .trailing)
+    }
+}
+
+#Preview("With Show Holding Column",traits: .sizeThatFitsLayout) {
+    
+    CoinRowView(coin: DeveloperPreviewProvider.instance.coin,showHoldingColumn: true)
+}
+
+#Preview("Without Show Holding Column",traits: .sizeThatFitsLayout) {
+    
+    CoinRowView(coin: DeveloperPreviewProvider.instance.coin,showHoldingColumn: false)
+}
+
+

--- a/CryptoAppSwiftUI/Core/HomeView/View/HomeView.swift
+++ b/CryptoAppSwiftUI/Core/HomeView/View/HomeView.swift
@@ -17,11 +17,17 @@ struct HomeView: View {
             
             VStack {
                 HomeHeaderView(showPortfolio: $homeViewModel.showPortfolio)
+                if !homeViewModel.showPortfolio {
+                    List {
+                        ForEach(homeViewModel.allCoins) { coin in
+                            CoinRowView(coin: coin, showHoldingColumn: false)
+                        }
+                    }
+                    .listStyle(PlainListStyle())
+                    .transition(.move(edge: .leading))
+                }
                 Spacer(minLength: 0)
-            }
-            
-            if homeViewModel.showPortfolio {
-                Text("Portfolio")
+
             }
         }
     }

--- a/CryptoAppSwiftUI/Core/HomeView/ViewModel/HomeViewModel.swift
+++ b/CryptoAppSwiftUI/Core/HomeView/ViewModel/HomeViewModel.swift
@@ -9,4 +9,13 @@ import Foundation
 
 final class HomeViewModel: ObservableObject {
     @Published var showPortfolio: Bool = false
+    @Published var allCoins: [CoinModel] = []
+    @Published var portfolioCoins: [CoinModel] = []
+    
+    init() {
+        DispatchQueue.main.asyncAfter(deadline: .now() + 2){
+            self.allCoins.append(DeveloperPreviewProvider.instance.coin)
+            self.portfolioCoins.append(DeveloperPreviewProvider.instance.coin)
+        }
+    }
 }

--- a/CryptoAppSwiftUI/CryptoAppSwiftUIApp.swift
+++ b/CryptoAppSwiftUI/CryptoAppSwiftUIApp.swift
@@ -9,6 +9,8 @@ import SwiftUI
 
 @main
 struct CryptoAppSwiftUIApp: App {
+    var coins : [CoinModel] = CoinModel.mockCoinData
+    
     var body: some Scene {
         WindowGroup {
             ContentView()

--- a/CryptoAppSwiftUI/Extension/PreviewProvider.swift
+++ b/CryptoAppSwiftUI/Extension/PreviewProvider.swift
@@ -1,0 +1,23 @@
+//
+//  PreviewProvider.swift
+//  CryptoAppSwiftUI
+//
+//  Created by Ömer Faruk Dikili on 8.02.2025.
+//
+
+import Foundation
+import SwiftUI
+
+//extension PreviewProvider{
+//    static var dev : DeveloperPreviewProvider{
+//        return DeveloperPreviewProvider.instance
+//    }
+//}
+
+class DeveloperPreviewProvider {
+    static let instance = DeveloperPreviewProvider()
+    
+    private init() {}
+    
+    let coin : CoinModel = CoinModel.mockCoinData.first!
+}

--- a/CryptoAppSwiftUI/Models/CoinModel.swift
+++ b/CryptoAppSwiftUI/Models/CoinModel.swift
@@ -60,6 +60,19 @@ struct CoinModel: Identifiable, Codable {
         return Int(marketCapRank ?? 0)
     }
     
+
+    static let mockCoinData: [CoinModel] = [
+        CoinModel(id: "bitcoin", symbol: "btc", name: "Bitcoin", image: "https://assets.coingecko.com/coins/images/1/large/bitcoin.png", currentPrice: 58908, marketCap: 1100013258170, marketCapRank: 1, fullyDilutedValuation: 1235028318246, totalVolume: 69075964521, high24H: 59504, low24H: 57672, priceChange24H: 808.94, priceChangePercentage24H: 1.39, marketCapChange24H: 13240944103, marketCapChangePercentage24H: 1.21, circulatingSupply: 18704250, totalSupply: 21000000, maxSupply: 21000000, ath: 64805, athChangePercentage: -9.24, athDate: "2021-04-14T11:54:46.763Z", atl: 67.81, atlChangePercentage: 86630.18, atlDate: "2013-07-06T00:00:00.000Z", lastUpdated: "2021-05-09T04:06:09.766Z", sparklineIn7D: SparklineIn7D(price: [57812.96, 57504.33]), priceChangePercentage24HInCurrency: 1.39, currentHoldings: 1.5),
+        
+        CoinModel(id: "ethereum", symbol: "eth", name: "Ethereum", image: "https://assets.coingecko.com/coins/images/279/large/ethereum.png", currentPrice: 3908, marketCap: 452001325817, marketCapRank: 2, fullyDilutedValuation: 503502831824, totalVolume: 29075964521, high24H: 3954, low24H: 3767, priceChange24H: 58.94, priceChangePercentage24H: 1.5, marketCapChange24H: 640944103, marketCapChangePercentage24H: 1.23, circulatingSupply: 115000000, totalSupply: nil, maxSupply: nil, ath: 4385, athChangePercentage: -10.2, athDate: "2021-05-12T11:54:46.763Z", atl: 0.43, atlChangePercentage: 908232.34, atlDate: "2015-10-20T00:00:00.000Z", lastUpdated: "2021-05-09T04:06:09.766Z", sparklineIn7D: SparklineIn7D(price: [3800.96, 3850.33]), priceChangePercentage24HInCurrency: 1.5, currentHoldings: 2.3),
+        
+        CoinModel(id: "cardano", symbol: "ada", name: "Cardano", image: "https://assets.coingecko.com/coins/images/975/large/cardano.png", currentPrice: 1.36, marketCap: 45200132581, marketCapRank: 5, fullyDilutedValuation: 50350283182, totalVolume: 5075964521, high24H: 1.40, low24H: 1.32, priceChange24H: 0.04, priceChangePercentage24H: 3.0, marketCapChange24H: 6409441, marketCapChangePercentage24H: 1.25, circulatingSupply: 32000000000, totalSupply: 45000000000, maxSupply: 45000000000, ath: 2.45, athChangePercentage: -44.3, athDate: "2021-09-02T11:54:46.763Z", atl: 0.017, atlChangePercentage: 8000.12, atlDate: "2017-10-01T00:00:00.000Z", lastUpdated: "2021-05-09T04:06:09.766Z", sparklineIn7D: SparklineIn7D(price: [1.33, 1.35]), priceChangePercentage24HInCurrency: 3.0, currentHoldings: 1000.0),
+        
+        CoinModel(id: "ripple", symbol: "xrp", name: "XRP", image: "https://assets.coingecko.com/coins/images/44/large/xrp.png", currentPrice: 0.85, marketCap: 39200132581, marketCapRank: 6, fullyDilutedValuation: 45350283182, totalVolume: 5075964521, high24H: 0.87, low24H: 0.81, priceChange24H: 0.02, priceChangePercentage24H: 2.5, marketCapChange24H: 409441, marketCapChangePercentage24H: 1.10, circulatingSupply: 100000000000, totalSupply: nil, maxSupply: nil, ath: 3.84, athChangePercentage: -78.2, athDate: "2018-01-04T11:54:46.763Z", atl: 0.002, atlChangePercentage: 41234.12, atlDate: "2013-08-02T00:00:00.000Z", lastUpdated: "2021-05-09T04:06:09.766Z", sparklineIn7D: SparklineIn7D(price: [0.83, 0.84]), priceChangePercentage24HInCurrency: 2.5, currentHoldings: 5000.0)
+    ]
+
+    // Yukarıdaki veri setine 6 coin daha ekleyerek genişletebilirsiniz.
+    
 }
 
 struct SparklineIn7D: Codable {


### PR DESCRIPTION

- Implemented `CoinRowView` to display coin details in a row format.
- Added conditional `showHoldingColumn` to toggle the holdings display.
- Separated layout into `leftColumn`, `centerColumn`, and `rightColumn` for better readability.
- Included two `#Preview` cases:
  - One with holdings column shown.
  - One without holdings column.
- Applied `sizeThatFitsLayout` trait for accurate preview rendering.