### PR TITLE
feat: Implement CoreData persistence for Portfolio management

### DIFF
--- a/CryptoAppSwiftUI/Models/PortfolioContainer.xcdatamodeld/PortfolioContainer.xcdatamodel/contents
+++ b/CryptoAppSwiftUI/Models/PortfolioContainer.xcdatamodeld/PortfolioContainer.xcdatamodel/contents
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="23605" systemVersion="24C101" minimumToolsVersion="Automatic" sourceLanguage="Swift" usedWithSwiftData="YES" userDefinedModelVersionIdentifier="">
+    <entity name="PortfolioEntity" representedClassName="PortfolioEntity" syncable="YES" codeGenerationType="class">
+        <attribute name="amount" optional="YES" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES"/>
+        <attribute name="coinID" optional="YES" attributeType="String"/>
+    </entity>
+</model>

--- a/CryptoAppSwiftUI/Services/PortfolioDataService.swift
+++ b/CryptoAppSwiftUI/Services/PortfolioDataService.swift
@@ -1,0 +1,78 @@
+//
+//  PortfolioDataService.swift
+//  CryptoAppSwiftUI
+//
+//  Created by Ömer Faruk Dikili on 19.02.2025.
+//
+
+import Foundation
+import CoreData
+
+class PortfolioDataService {
+    private let container: NSPersistentContainer
+    private let containerName = "PortfolioContainer"
+    private let entityName = "PortfolioEntity"
+    @Published var savedEnities: [PortfolioEntity] = []
+    init() {
+        container = NSPersistentContainer(name: containerName)
+        container.loadPersistentStores { description, error in
+            if let error = error as NSError? {
+                fatalError("Unresolved error \(error), \(error.userInfo)")
+            }
+            self.getPortfolio()
+        }
+    }
+    
+    public func updatePortfolio(coin : CoinModel , amount : Double){
+        if let entity =  savedEnities.first(where: {$0.coinID == coin.id}){
+            if(entity.amount>0){
+                update(entity: entity, amount: amount)
+            }else{
+                remove(entity: entity)
+            }
+        }else{
+            add(coin: coin, amount: amount)
+        }
+    }
+    
+    private func getPortfolio() {
+        let request = NSFetchRequest<PortfolioEntity>(entityName: entityName)
+        do{
+          savedEnities =  try container.viewContext.fetch(request)
+        }catch let error as NSError{
+            print("Error fetcing Portfolio: \(error)")
+        }
+    }
+    
+    private func add(coin : CoinModel , amount : Double) {
+      let entity = PortfolioEntity(context: container.viewContext)
+        
+        entity.coinID = coin.id
+        entity.amount = amount
+        applyChanges()
+        
+    }
+    
+    private func update(entity : PortfolioEntity , amount : Double) {
+        entity.amount = amount
+        applyChanges()
+    }
+    
+    private func remove(entity: PortfolioEntity){
+        container.viewContext.delete(entity)
+        applyChanges()
+    }
+    
+    private func save(){
+        do{
+            try container.viewContext.save()
+        }catch let error as NSError{
+                print("Error saving Portfolio: \(error)")
+        }
+    }
+    
+    private func applyChanges(){
+        save( )
+        getPortfolio()
+    }
+}


### PR DESCRIPTION
- Integrated CoreData with `PortfolioDataService` using `NSPersistentContainer`
- Implemented CRUD operations:
  - `getPortfolio()`: Fetches saved portfolio entities
  - `add(coin:amount:)`: Adds a new portfolio entity
  - `update(entity:amount:)`: Updates an existing entity
  - `remove(entity:)`: Deletes an entity
  - `applyChanges()`: Saves changes and refreshes portfolio data
- Ensured data persistence with `save()` and error handling