### PR TITLE
feat(sorting): Implement sorting functionality for holdings

### DIFF
--- a/CryptoAppSwiftUI.xcodeproj/xcuserdata/omerfarukdikili.xcuserdatad/xcdebugger/Breakpoints_v2.xcbkptlist
+++ b/CryptoAppSwiftUI.xcodeproj/xcuserdata/omerfarukdikili.xcuserdatad/xcdebugger/Breakpoints_v2.xcbkptlist
@@ -52,5 +52,21 @@
             landmarkType = "24">
          </BreakpointContent>
       </BreakpointProxy>
+      <BreakpointProxy
+         BreakpointExtensionID = "Xcode.Breakpoint.FileBreakpoint">
+         <BreakpointContent
+            uuid = "49102968-B8C3-49EB-AA04-C1ACFE3740A3"
+            shouldBeEnabled = "No"
+            ignoreCount = "0"
+            continueAfterRunningActions = "No"
+            filePath = "CryptoAppSwiftUI/Core/HomeView/ViewModel/HomeViewModel.swift"
+            startingColumnNumber = "9223372036854775807"
+            endingColumnNumber = "9223372036854775807"
+            startingLineNumber = "106"
+            endingLineNumber = "106"
+            landmarkName = "sortPortfolioCoinsIfNeeded(coins:)"
+            landmarkType = "7">
+         </BreakpointContent>
+      </BreakpointProxy>
    </Breakpoints>
 </Bucket>

--- a/CryptoAppSwiftUI/Core/HomeView/View/HomeView.swift
+++ b/CryptoAppSwiftUI/Core/HomeView/View/HomeView.swift
@@ -99,11 +99,32 @@ private extension HomeView {
     
     private var columnTitles : some View{
         HStack{
-            Text("Coin")
+            HStack{
+                Text("Coin")
+                Image(systemName: "chevron.down")
+                    .opacity(homeViewModel.selectedCoinSortType == .rank || homeViewModel.selectedCoinSortType == .rankReverse ? 1 : 0)
+                    .rotationEffect(Angle(degrees: homeViewModel.selectedCoinSortType == .rank ? 0: 180))
+                   
+            } .onTapGesture {
+                withAnimation(.default) {
+                    homeViewModel.selectedCoinSortType =  homeViewModel.selectedCoinSortType
+                    == .rank ? .rankReverse : .rank
+                }
+            }
             Spacer()
             if(homeViewModel.showPortfolio){
-                Text("Holdings")
-                   
+                HStack{
+                    Text("Holdings")
+                    Image(systemName: "chevron.down")
+                        .opacity(homeViewModel.selectedCoinSortType == .holdings || homeViewModel.selectedCoinSortType == .holdingsReverse ? 1 : 0)
+                        .rotationEffect(Angle(degrees: homeViewModel.selectedCoinSortType == .holdings ? 0: 180))
+                                        }.onTapGesture {
+                                            withAnimation(.default) {
+                                                homeViewModel.selectedCoinSortType =  homeViewModel.selectedCoinSortType
+                                                == .holdings ? .holdingsReverse : .holdings
+                                            }
+                                        }
+
             }
            
             Text("Price") .frame(width: UIScreen.main.bounds.width/3.5,alignment: .trailing)

--- a/CryptoAppSwiftUI/Enums/CoinSortType.swift
+++ b/CryptoAppSwiftUI/Enums/CoinSortType.swift
@@ -1,0 +1,13 @@
+//
+//  CoinSortType.swift
+//  CryptoAppSwiftUI
+//
+//  Created by Ömer Faruk Dikili on 20.02.2025.
+//
+
+import Foundation
+
+enum CoinSortType{
+    case rank,rankReverse,price,priceReverse,holdings,holdingsReverse
+    
+}


### PR DESCRIPTION
- Added sorting logic in `HomeViewModel` to toggle between `.holdings` and `.holdingsReverse`.
- Implemented sorting conditions in `sortCoins` and `sortPortfolioCoinsIfNeeded` functions.
- Updated `HStack` UI to reflect sorting state changes with rotation and opacity effects.
- Applied sorting in the Combine pipeline when filtering and updating coins.